### PR TITLE
Adds not regarding "DNS name does not exist" error.

### DIFF
--- a/docs/en/FAQs.md
+++ b/docs/en/FAQs.md
@@ -26,6 +26,19 @@ Possible Responses:
 
 If you do not receive a response (NXDOMAIN), then Quad9 was not used to perform this DNS query.
 
+### Resolve-DnsName : proto.on.quad9.net. : DNS name does not exist
+
+If you are using Windows and receive the following message from Powershell when running the `Resolve-DnsName` query, consider disabling your VPN:
+
+```plaintext
+Resolve-DnsName : proto.on.quad9.net. : DNS name does not exist
+At line:1 char:1
++ Resolve-DnsName -Type txt proto.on.quad9.net.
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : ResourceUnavailable: (proto.on.quad9.net.:String) [Resolve-DnsName], Win32Exception
+    + FullyQualifiedErrorId : DNS_ERROR_RCODE_NAME_ERROR,Microsoft.DnsClient.Commands.ResolveDnsName
+```
+
 ## Identifying a Quad9 block
 
 The quickest way to see if a domain is blocked at Quad9 is using our [Blocked Domain Tester](https://quad9.net/result).


### PR DESCRIPTION
I encountered this error when attempting to run the `Resolve-DnsName -Type txt proto.on.quad9.net.` command:

```
Resolve-DnsName : proto.on.quad9.net. : DNS name does not exist
At line:1 char:1
+ Resolve-DnsName -Type txt proto.on.quad9.net.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceUnavailable: (proto.on.quad9.net.:String) [Resolve-DnsName], Win32Exception
    + FullyQualifiedErrorId : DNS_ERROR_RCODE_NAME_ERROR,Microsoft.DnsClient.Commands.ResolveDnsName
```

I was being a bit of an idiot and completely forgot to disable my VPN client first. Once I did that, the error went away and I was able to continue using this FAQ guide.

Repo owners: feel free to edit or delete this PR if it doesn't fit.