### PR TITLE
Fix typos in linux setup guide

### DIFF
--- a/docs/en/Setup_Guides/Linux_and_BSD/Ubuntu_22.04_(Encrypted).md
+++ b/docs/en/Setup_Guides/Linux_and_BSD/Ubuntu_22.04_(Encrypted).md
@@ -34,7 +34,7 @@ sudo systemctl restart systemd-resolved.service && sudo service network-manager 
 * Confirm that DNS over TLS is being used by opening the `Terminal` application and running the following command, typing in your password and pressing `Enter``:
 
 ```
-$ dig +short txt proto.on.quad9.net.
+dig +short txt proto.on.quad9.net.
 ```
 If the response is `dot.`, then it is working! If the response is `do53-udp.`, then it's still using plaintext. If there is no response, that means that Quad9 may not have been configured probably in the `Network Settings`.
 

--- a/docs/en/Setup_Guides/Linux_and_BSD/Ubuntu_22.04_(Encrypted).md
+++ b/docs/en/Setup_Guides/Linux_and_BSD/Ubuntu_22.04_(Encrypted).md
@@ -27,7 +27,7 @@ sudo sed -i 's/#DNSOverTLS=no/DNSOverTLS=yes/g' /etc/systemd/resolved.conf
 * Restart the `systemd-resolvd` and `networking services` to recognize the changes to the file:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 ## Verify Configuration
 
@@ -51,7 +51,7 @@ sudo sed -i 's/DNSOverTLS=yes/#DNSOverTLS=no/g' /etc/systemd/resolved.conf
 * Restart the `systemd-resolvd` and `networking` services to recognize the changes to the file we just made:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 
 Questions? Issues? Didn't work? Contact us!

--- a/docs/es/Guías_de_configuración/Linux_y_BSD/Ubuntu_22.04_(Encriptado).md
+++ b/docs/es/Guías_de_configuración/Linux_y_BSD/Ubuntu_22.04_(Encriptado).md
@@ -27,7 +27,7 @@ sudo sed -i 's/#DNSOverTLS=no/DNSOverTLS=yes/g' /etc/systemd/resolved.conf
 * Reinicie `systemd-resolvd` y `networking services` para reconocer los cambios en el archivo:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 ## Verificar configuración
 
@@ -52,7 +52,7 @@ sudo sed -i 's/DNSOverTLS=yes/#DNSOverTLS=no/g' /etc/systemd/resolved.conf
 * Reinicie los servicios `systemd-resolvd` y `networking` para reconocer los cambios en el archivo que acabamos de realizar:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 
 ¿Preguntas? ¿Asuntos? ¿No funcionó? ¡Contáctenos!

--- a/docs/es/Guías_de_configuración/Linux_y_BSD/Ubuntu_22.04_(Encriptado).md
+++ b/docs/es/Guías_de_configuración/Linux_y_BSD/Ubuntu_22.04_(Encriptado).md
@@ -34,7 +34,7 @@ sudo systemctl restart systemd-resolved.service && sudo service network-manager 
 * Confirme que se está utilizando DNS sobre TLS abriendo la aplicación `Terminal` y ejecutando el siguiente comando, escribiendo su contraseña y presionando `Enter`:
 
 ```
-$ dig +short txt proto.on.quad9.net.
+dig +short txt proto.on.quad9.net.
 
 ```
 Si la respuesta es `dot.`, ¡entonces está funcionando! Si la respuesta es `do53-udp.`, entonces todavía está usando texto sin formato. Si no hay respuesta, eso significa que es posible que Quad9 no se haya configurado probablemente en la `Network Settings`.

--- a/docs/fr/Guides_de_configuration/Linux_et_BSD/Ubuntu_22.04_(Chiffré).md
+++ b/docs/fr/Guides_de_configuration/Linux_et_BSD/Ubuntu_22.04_(Chiffré).md
@@ -32,7 +32,7 @@ sudo systemctl restart systemd-resolved.service && sudo service network-manager 
 * Verifiez que DNS over TLS est actif en ouvrant l'application `Terminal` et entrez les commandes suivantes, saisissez votre mot de passe et appuyez sur `Entrée`:
 
 ```
-$ dig +short txt proto.on.quad9.net.
+dig +short txt proto.on.quad9.net.
 ```
 Si la réponse est `dot.`, cela signifie que ca marche! Si la réponse est `do53-udp.`, alors il utilise encore du plaintext. S'il n'y a pas de réponse, cela signifie que Quad9 n'a probablement pas été configuré dans le `Paramètres réseau`.
 

--- a/docs/fr/Guides_de_configuration/Linux_et_BSD/Ubuntu_22.04_(Chiffré).md
+++ b/docs/fr/Guides_de_configuration/Linux_et_BSD/Ubuntu_22.04_(Chiffré).md
@@ -25,7 +25,7 @@ sudo sed -i 's/#DNSOverTLS=no/DNSOverTLS=yes/g' /etc/systemd/resolved.conf
 * Redémarer `systemd-resolvd` et `networking services` afin d'enregistrer les changements dans le fichier:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 ## Verifier la Configuration
 
@@ -49,7 +49,7 @@ sudo sed -i 's/DNSOverTLS=yes/#DNSOverTLS=no/g' /etc/systemd/resolved.conf
 * Redémarrez les services `systemd-resolvd` et `networking` afin d'enregistrer les changements que nous venons d'effectuer dans le fichier:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 
 Vous avez des questions? Vous rencontrez un probleme? Cela n'a pas marché? N'hésitez pas à nous contacter!

--- a/docs/ro/Ghiduri_de_configurare/Linux_și_BSD/Ubuntu_22.04_(Criptat).md
+++ b/docs/ro/Ghiduri_de_configurare/Linux_și_BSD/Ubuntu_22.04_(Criptat).md
@@ -27,7 +27,7 @@ sudo sed -i 's/#DNSOverTLS=no/DNSOverTLS=yes/g' /etc/systemd/resolved.conf
 * Reporniți `systemd-resolvd` și `networking services` pentru a recunoaște modificările la fișier:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 ## Verificarea configurației
 
@@ -51,7 +51,7 @@ sudo sed -i 's/DNSOverTLS=yes/#DNSOverTLS=no/g' /etc/systemd/resolved.conf
 * Reporniți serviciile `systemd-resolvd` și `networking` pentru a recunoaște modificările aduse fișierului pe care tocmai le-am făcut:
 
 ```
-sudo systemctl restart systemd-resolved.service && sudo service network-manager restart
+sudo systemctl restart systemd-resolved.service && sudo service NetworkManager restart
 ```
 
 Întrebări? Probleme? Nu a funcționat? Contactați-ne!

--- a/docs/ro/Ghiduri_de_configurare/Linux_și_BSD/Ubuntu_22.04_(Criptat).md
+++ b/docs/ro/Ghiduri_de_configurare/Linux_și_BSD/Ubuntu_22.04_(Criptat).md
@@ -34,7 +34,7 @@ sudo systemctl restart systemd-resolved.service && sudo service network-manager 
 * Confirmați că DNS over TLS este utilizat deschizând aplicația `Terminal` și executând următoarea comandă, introducând parola și apăsând `Enter`:
 
 ```
-$ dig +short txt proto.on.quad9.net.
+dig +short txt proto.on.quad9.net.
 ```
 Dacă răspunsul este `dot.`, atunci funcționează! Dacă răspunsul este `do53-udp.`, atunci încă se folosește text clar. Dacă nu există niciun răspuns, înseamnă că Quad9 nu a fost configurat probabil în `Network Settings`.
 


### PR DESCRIPTION
In the Setup Guide for DNS over TLS on Ubuntu there seemed to be two typos in the command lines. I dared to fix them in all translations as no text in the languages was affected.