### PR TITLE
Restore custom domain for GitHub Pages (#17)

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.quad9.net

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Quad9 Documentation
-site_url: https://quad9dns.github.io/documentation
+site_url: https://docs.quad9.net/
 repo_url: https://github.com/Quad9DNS/documentation
 
 plugins:


### PR DESCRIPTION
`mkdocs gh-deploy --force` wipes gh-pages on every run, so the CNAME must live in the source tree. Add docs/CNAME and point site_url at the real host.

Thanks to @mttaggart for catching the missing CNAME and reporting it.